### PR TITLE
Ghost 1.x.x Compatibility

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -11,7 +11,7 @@
           <time class="post-date" datetime="{{date format='YYYY-MM-DD'}}">{{date format="MMMM DD, YYYY"}}</time>
           <span class="tags">{{tags}}</span>
       </section>
-      {{#if image}}<img class="post-image" src="{{image}}">{{/if}}
+      {{#if feature_image}}<img class="post-image" src="{{img_url feature_image}}">{{/if}}
   </header>
 
 

--- a/tag.hbs
+++ b/tag.hbs
@@ -2,7 +2,7 @@
     {{#tag}}
     <header class="tag-header">
         <h1 class="tag-title">{{name}}</h1>
-        {{#if image}}<img class="tag-image" src="{{image}}">{{/if}}
+        {{#if feature_image}}<img class="tag-image" src="{{img_url feature_image}}">{{/if}}
         <p class="tag-description">{{description}}</p>
     </header>
     {{/tag}}


### PR DESCRIPTION
Simple fixes to suppress the warnings when attempting to use oscar-ghost with the Ghost 1.x.x update